### PR TITLE
migrate DocuSun to Local-Only Models and Configurations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,12 @@
-# GitHub Models token (required when provider=api)
-DocuSun_GITHUB_TOKEN=
+# Local LLM configuration (Ollama) - required
+DOCUSUN_LLM_MODEL= # Your_installed_local_llm (e.g., llama3.1:8b-instruct-q4_K_M)
+DOCUSUN_OLLAMA_BASE_URL= # Your_ollama_base_url (e.g., http://localhost:11434)
 
-# Embedding backend: api or local
-DOCUSUN_EMBEDDING_PROVIDER=api
-
-# Optional model override
-# For api: text-embedding-3-small
-# For local: google/embeddinggemma-300m
-DOCUSUN_EMBEDDING_MODEL=text-embedding-3-small
+# Local embedding model - required
+DOCUSUN_EMBEDDING_MODEL= # Your_local_embedding_model (e.g., google/embeddinggemma-300m)
 
 # Used only for local embeddings
-DOCUSUN_EMBEDDING_DEVICE=cpu
+DOCUSUN_EMBEDDING_DEVICE= # Your_device (e.g., cpu, cuda, mps)
 
-# Tokenizer model used for chunking (Hugging Face model name)
-DOCUSUN_TOKENIZER_MODEL=gpt2
+# Tokenizer model used for chunking (Hugging Face model name) - required
+DOCUSUN_TOKENIZER_MODEL= # Your_tokenizer_model (e.g., gpt2)

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ output.txt
 engine/ingestion/main.py
 .env
 chroma_db/
-chroma_db_api_text-embedding-3-small/
+chroma_db_local_*

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Core stack includes:
 - loguru  
 - python-dotenv  
 - streamlit (for future UI)  
-- langchain-openai / API-compatible model access  
+- langchain-ollama (local LLM inference)  
 
 
 
 ## Installation (Terminal)
 
 ```bash
-git clone <your-repo-url>
+git clone https://github.com/HIS-MOHAMMED/docuSun.git
 cd docuSun
 
 python3 -m venv .venv
@@ -95,17 +95,15 @@ pip install -e .
 
 ## Environment Setup
 
-Create a `.env` file in the project root (if using API-based models):
+Create a `.env` file in the project root. `DOCUSUN_LLM_MODEL`, `DOCUSUN_OLLAMA_BASE_URL`, `DOCUSUN_EMBEDDING_MODEL`, and `DOCUSUN_TOKENIZER_MODEL` are required:
 
 ```env
-DocuSun_GITHUB_TOKEN=your_token_here
-DOCUSUN_EMBEDDING_PROVIDER=api
-DOCUSUN_EMBEDDING_MODEL=text-embedding-3-small
-DOCUSUN_EMBEDDING_DEVICE=cpu
-DOCUSUN_TOKENIZER_MODEL=gpt2
+DOCUSUN_LLM_MODEL= # Your_installed_local_llm (e.g., llama3.1:8b-instruct-q4_K_M)
+DOCUSUN_OLLAMA_BASE_URL= # Your_ollama_base_url (e.g., http://localhost:11434)
+DOCUSUN_EMBEDDING_MODEL= # Your_local_embedding_model (e.g., google/embeddinggemma-300m)
+DOCUSUN_EMBEDDING_DEVICE= # Your_device (e.g., cpu, cuda, mps)
+DOCUSUN_TOKENIZER_MODEL= # Your_tokenizer_model (e.g., gpt2)
 ```
-
-For local embeddings, switch provider to `local` and choose a local embedding model name.
 
 
 
@@ -118,7 +116,7 @@ docusun index --data_path data --chunk_size 400 --top_k 3
 
 ### Ask a question:
 ```bash
-docusun query --question "What are the main findings?" --top_k 3
+docusun query --question "type_your_question_here" --top_k 3
 ```
 
 

--- a/engine/embedding/encoder.py
+++ b/engine/embedding/encoder.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Sequence, Optional
-from engine.embedding.models import load_embedding_model, load_embedding_model_api
+from engine.embedding.models import load_embedding_model
 
 
 class Encoder:
@@ -11,32 +11,22 @@ class Encoder:
     def __init__(
         self,
         embedding_model: Optional[Any] = None,
-        model_name: str = "text-embedding-3-small",
-        provider: str = "api",
+        model_name: Optional[str] = None,
         device: str = "cpu",
     ):
         """
         Initialize the encoder. If an embedding model is not provided,
-        load one using the selected provider.
-
-        Parameters:
-        - provider: "api" for GitHub Models endpoint, "local" for HuggingFace local model.
+        load one locally using the selected model.
         """
-        provider = (provider or "api").strip().lower()
-        if provider not in {"api", "local"}:
-            raise ValueError("Invalid embedding provider. Use 'api' or 'local'.")
-
         if embedding_model:
             self.embedding_model = embedding_model
-        elif provider == "local":
-            self.embedding_model = load_embedding_model(
-                model_name=model_name,
-                device=device,
-            )
-        else:
-            self.embedding_model = load_embedding_model_api(
-                model_name=model_name,
-            )
+            return
+        if not model_name:
+            raise ValueError("model_name is required when embedding_model is not provided.")
+        self.embedding_model = load_embedding_model(
+            model_name=model_name,
+            device=device,
+        )
 
     def embed_documents(self, texts: Sequence[str]) -> List[List[float]]:
         """

--- a/engine/embedding/models.py
+++ b/engine/embedding/models.py
@@ -1,6 +1,4 @@
-import os
 from langchain_huggingface import HuggingFaceEmbeddings
-from langchain_openai import OpenAIEmbeddings
 
 def load_embedding_model(
     model_name,
@@ -28,35 +26,4 @@ def load_embedding_model(
         return embedding_model
     except Exception as e:
         print(f"An error accurred while loading the local model: {e}")
-        raise
-
-
-def load_embedding_model_api(
-    model_name,
-)-> OpenAIEmbeddings:
-    """
-    Loads an embedding model from the GitHub Models API using the OpenAI-compatible endpoint.
-
-    Parameters:
-    - model_name: The name of the embedding model to load.
-
-    Returns:
-    - An instance of OpenAIEmbeddings configured for GitHub Models.
-
-    Raises:
-    - ValueError: If GITHUB_TOKEN is not configured.
-    """
-    try:
-        github_token = os.environ.get("DocuSun_GITHUB_TOKEN")
-        if not github_token:
-            raise ValueError("GITHUB_TOKEN is not set. Please configure it in your environment.")
-
-        embedding_model = OpenAIEmbeddings(
-            model=model_name,
-            api_key=github_token,
-            base_url="https://models.inference.ai.azure.com",
-        )
-        return embedding_model
-    except Exception as e:
-        print(f"An error accurred while loading the API model: {e}")
         raise

--- a/engine/qa/llm.py
+++ b/engine/qa/llm.py
@@ -1,17 +1,26 @@
 import os
-from langchain_openai import ChatOpenAI
+from langchain_ollama import ChatOllama
 
-LLM_MODEL_NAME = "gpt-5"
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required but not set.")
+    return value
 
 
 def get_llm_model_name() -> str:
-    return LLM_MODEL_NAME
+    return _require_env("DOCUSUN_LLM_MODEL")
+
+
+def get_llm_base_url() -> str:
+    return _require_env("DOCUSUN_OLLAMA_BASE_URL")
+
 
 def get_llm():
-    llm = ChatOpenAI(
-        model=LLM_MODEL_NAME,
-        api_key=os.environ.get("DocuSun_GITHUB_TOKEN"), 
-        base_url="https://models.inference.ai.azure.com",
-        temperature=0
+    llm = ChatOllama(
+        model=get_llm_model_name(),
+        base_url=get_llm_base_url(),
+        temperature=0,
     )
-    return llm 
+    return llm

--- a/engine/qa/pipeline.py
+++ b/engine/qa/pipeline.py
@@ -24,16 +24,17 @@ from engine.store.chroma_store import get_retriever, load_retriever
 #load environment variables from .evn file 
 load_dotenv()
 
-EMBEDDING_PROVIDER = os.environ.get("DOCUSUN_EMBEDDING_PROVIDER", "api").strip().lower()
-if EMBEDDING_PROVIDER not in {"api", "local"}:
-    raise ValueError("DOCUSUN_EMBEDDING_PROVIDER must be either 'api' or 'local'.")
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required but not set.")
+    return value
 
-EMBEDDING_MODEL_NAME = os.environ.get(
-    "DOCUSUN_EMBEDDING_MODEL",
-    "text-embedding-3-small" if EMBEDDING_PROVIDER == "api" else "google/embeddinggemma-300m",
-).strip()
+
+EMBEDDING_PROVIDER = "local"
+EMBEDDING_MODEL_NAME = _require_env("DOCUSUN_EMBEDDING_MODEL")
 EMBEDDING_DEVICE = os.environ.get("DOCUSUN_EMBEDDING_DEVICE", "cpu").strip()
-DOCUSUN_TOKENIZER_MODEL = os.environ.get("DOCUSUN_TOKENIZER_MODEL", "gpt2").strip()
+DOCUSUN_TOKENIZER_MODEL = _require_env("DOCUSUN_TOKENIZER_MODEL")
 
 
 def _default_persist_directory(provider: str, model_name: str) -> str:
@@ -92,7 +93,6 @@ def index_documents(
     _emit(log_fn, "kv", "Chunks created", len(chunks))
     _emit(log_fn, "chunks", "Chunks (first 10)", _format_chunk_previews(chunks, limit=10))
 
-    _emit(log_fn, "kv", "Embedding provider", EMBEDDING_PROVIDER)
     _emit(log_fn, "kv", "Embedding model", EMBEDDING_MODEL_NAME)
     _emit(log_fn, "kv", "Persist directory", persist_directory)
 
@@ -114,7 +114,6 @@ def index_documents(
 
     encoder = Encoder(
         model_name=EMBEDDING_MODEL_NAME,
-        provider=EMBEDDING_PROVIDER,
         device=EMBEDDING_DEVICE,
     )
     _emit(log_fn, "step", "Persisting embeddings")
@@ -136,7 +135,6 @@ def query_documents(
 ):
     if not persist_directory:
         persist_directory = _default_persist_directory(EMBEDDING_PROVIDER, EMBEDDING_MODEL_NAME)
-    _emit(log_fn, "kv", "Embedding provider", EMBEDDING_PROVIDER)
     _emit(log_fn, "kv", "Embedding model", EMBEDDING_MODEL_NAME)
     _emit(log_fn, "kv", "Persist directory", persist_directory)
     _emit(log_fn, "kv", "Top k", top_k)
@@ -146,7 +144,6 @@ def query_documents(
     _emit(log_fn, "step", "Loading retriever")
     encoder = Encoder(
         model_name=EMBEDDING_MODEL_NAME,
-        provider=EMBEDDING_PROVIDER,
         device=EMBEDDING_DEVICE,
     )
     retriever = load_retriever(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ chromadb
 rank_bm25
 matplotlib
 jsonargparse
-langchain-openai
 pymupdf
 streamlit
-cohere
+langchain-ollama
 python-dotenv


### PR DESCRIPTION
- Removed all hardcoded defaults for DOCUSUN_LLM_MODEL, DOCUSUN_EMBEDDING_MODEL, and DOCUSUN_TOKENIZER_MODEL.
- Enforced these values to be provided via environment variables.
- DOCUSUN_OLLAMA_BASE_URL is now required with no default.
- Updated llm.py to require DOCUSUN_LLM_MODEL and DOCUSUN_OLLAMA_BASE_URL.
- Updated pipeline.py to require DOCUSUN_EMBEDDING_MODEL and DOCUSUN_TOKENIZER_MODEL.
- Updated encoder.py to remove default embedding model and enforce explicit configuration.
- Updated .env.example to include placeholders for all required variables with clear comments.
- Updated README.md to clarify required environment variables and their purpose.
- Removed "Embedding provider" from CLI logs for both indexing and querying.
